### PR TITLE
Add settings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,32 @@
  * @license Apache-2.0
  */
 
+const configName = 'triage.yml'
+
+/**
+ * Returns the triage label reading it from the settings. If the label is not defined it returns 'triage'
+ *
+ * @param   {Object} `context` Probot webhook event context
+ * @returns {Promise} A Promise that fulfills with the label when the action is complete
+ */
+async function triageLabel(context) {
+  const config = await context.config(configName)
+  const label = config['label']
+  return label ? label : 'triage'
+}
+
+/**
+ * Returns whether the triage labeling is enabled or not. If it's not defined in the settings it returns true as a default value.
+ *
+ * @param   {Object} `context` Probot webhook event context
+ * @returns {Promise} A Promise that fulfills with the enabled value when the action is complete
+ */
+async function enabled(context) {
+  const config = await context.config(configName)
+  const enabled = config['enabled']
+  return enabled === true
+}
+
 /**
  * Adds the triage label if the issue has no labels on it.
  *
@@ -12,9 +38,11 @@
  * @private
  */
 
-async function triage (context) {
+async function triage(context) {
   const { payload, github } = context
-
+  if (!(await enabled(context))) {
+    return
+  }
   if (!payload.issue || payload.issue.labels.length === 0) {
     /*
      * Fetch the issue again to double-check that it has no labels.
@@ -22,10 +50,11 @@ async function triage (context) {
      * webhook event contains no labels.
      * https://github.com/eslint/eslint-github-bot/issues/38
      */
-    const issue = await github.issues.get(context.issue()).then((res) => res.data)
+    const issue = await github.issues.get(context.issue()).then(res => res.data)
 
     if (issue.labels.length === 0) {
-      await github.issues.addLabels(context.issue({ labels: ['triage'] }))
+      const label = await triageLabel(context)
+      await github.issues.addLabels(context.issue({ labels: [label] }))
     }
   }
 }
@@ -38,11 +67,14 @@ async function triage (context) {
  * @private
  */
 
-async function check (context) {
+async function check(context) {
   const { payload, github } = context
-
-  if (payload.label && payload.label.name !== 'triage') {
-    await github.issues.removeLabel(context.issue({ name: 'triage' }))
+  if (!(await enabled(context))) {
+    return
+  }
+  const label = await triageLabel(context)
+  if (payload.label && payload.label.name !== label) {
+    await github.issues.removeLabel(context.issue({ name: label }))
   }
 }
 
@@ -50,7 +82,7 @@ async function check (context) {
  * Add triage label when an issue is opened or reopened
  */
 
-module.exports = (robot) => {
+module.exports = robot => {
   robot.on('issues.opened', triage)
   robot.on('issues.labeled', check)
   robot.on('issues.reopened', triage)


### PR DESCRIPTION
This PR allows customising two things in the probot:
- **The label that is used for triaging:** We would like to use this probot but our repositories use the label `Untriaged` instead.
- **Enable/disable it**: We'd like to enable the probot at the organization level and enable/disable it in a per-repository basis.

Changes are not breaking so any project already using this probot can continue using the probot without any changes on their side. If settings are not defined, the values default to the ones that were in the project.

